### PR TITLE
rename to `liquibase-opensearch-spring-boot-starter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# liquibase-opensearch-springboot-starter
+# liquibase-opensearch-spring-boot-starter
 
 Liquibase extension for OpenSearch Springboot Starter

--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,9 @@
     </parent>
 
     <groupId>org.liquibase.ext</groupId>
-    <artifactId>liquibase-opensearch-springboot-starter</artifactId>
+    <artifactId>liquibase-opensearch-spring-boot-starter</artifactId>
     <version>0.0.1-SNAPSHOT</version>
-    <name>Liquibase Opensearch Springboot Starter Extension</name>
+    <name>Liquibase Opensearch Spring Boot Starter Extension</name>
     <packaging>jar</packaging>
 
 


### PR DESCRIPTION
as per [the official spring docs] the name should end with `spring-boot-starter` (note the dash between `spring` and `boot`).

the repository should be renamed accordingly, at which point the URLs in `pom.xml` should be changed as well.

part of #14

[the official spring docs]: https://docs.spring.io/spring-boot/reference/features/developing-auto-configuration.html#features.developing-auto-configuration.custom-starter.naming